### PR TITLE
Add policy pages with footer links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -280,6 +280,13 @@ function AppShell() {
             }
           />
 
+          {/* Policy Pages */}
+          <Route path="/terms" element={<TermsConditions />} />
+          <Route path="/privacy" element={<PrivacyPolicy />} />
+          <Route path="/pricing-policy" element={<PricingPolicy />} />
+          <Route path="/delivery-policy" element={<DeliveryPolicy />} />
+          <Route path="/cancellation-refund" element={<CancellationRefundPolicy />} />
+
           {/* Dev helpers */}
           {import.meta.env.DEV && (
             <>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,11 @@ import AdminDashboard from "./components/AdminDashboard";
 import AdminUserDetail from "./components/AdminUserDetail";
 import ApiDebug from "./components/ApiDebug";
 import RazorpayTest from "./components/RazorpayTest";
+import TermsConditions from "./components/TermsConditions";
+import PrivacyPolicy from "./components/PrivacyPolicy";
+import PricingPolicy from "./components/PricingPolicy";
+import DeliveryPolicy from "./components/DeliveryPolicy";
+import CancellationRefundPolicy from "./components/CancellationRefundPolicy";
 
 const LOCAL_USER_KEY = "udin:user";       // where signup stores user profile
 const ACCESS_TOKEN_KEY = "accessToken";   // where we store JWT access token

--- a/src/components/CancellationRefundPolicy.jsx
+++ b/src/components/CancellationRefundPolicy.jsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const CancellationRefundPolicy = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="bg-white rounded-lg shadow-sm p-8">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-8">
+            <h1 className="text-3xl font-bold text-gray-900">Cancellation & Refund Policy</h1>
+            <button
+              onClick={() => navigate(-1)}
+              className="px-4 py-2 text-sm font-medium text-gray-600 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+            >
+              ← Back
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="prose prose-lg max-w-none">
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Cancellation Policy</h2>
+              <div className="bg-red-50 border border-red-200 rounded-lg p-6 mb-4">
+                <div className="flex items-center mb-2">
+                  <div className="w-6 h-6 bg-red-500 rounded-full mr-2 flex items-center justify-center">
+                    <span className="text-white text-xs font-bold">!</span>
+                  </div>
+                  <h3 className="font-semibold text-red-900">Important Cancellation Window</h3>
+                </div>
+                <p className="text-red-800 text-sm">
+                  Cancellations are allowed only before document verification starts.
+                </p>
+              </div>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Once verification or signing begins, cancellation is not possible.</li>
+                <li>The cancellation window closes when our team begins processing your documents.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Refund Conditions</h2>
+              
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+                <div className="bg-green-50 border border-green-200 rounded-lg p-6">
+                  <div className="flex items-center mb-3">
+                    <div className="w-8 h-8 bg-green-500 rounded-full mr-2 flex items-center justify-center">
+                      <span className="text-white text-sm">✓</span>
+                    </div>
+                    <h3 className="font-semibold text-green-900">Full Refund</h3>
+                  </div>
+                  <p className="text-green-800 text-sm">
+                    If service cannot be provided due to internal/system error.
+                  </p>
+                </div>
+
+                <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6">
+                  <div className="flex items-center mb-3">
+                    <div className="w-8 h-8 bg-yellow-500 rounded-full mr-2 flex items-center justify-center">
+                      <span className="text-white text-sm">~</span>
+                    </div>
+                    <h3 className="font-semibold text-yellow-900">Partial Refund</h3>
+                  </div>
+                  <p className="text-yellow-800 text-sm">
+                    If only part of the service is delivered (case-by-case basis).
+                  </p>
+                </div>
+
+                <div className="bg-red-50 border border-red-200 rounded-lg p-6">
+                  <div className="flex items-center mb-3">
+                    <div className="w-8 h-8 bg-red-500 rounded-full mr-2 flex items-center justify-center">
+                      <span className="text-white text-sm">✕</span>
+                    </div>
+                    <h3 className="font-semibold text-red-900">No Refund</h3>
+                  </div>
+                  <p className="text-red-800 text-sm">
+                    If user submits wrong/incomplete documents or cancels after processing starts.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Refund Process</h2>
+              <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-4">
+                <h3 className="font-semibold text-blue-900 mb-2">How to Request a Refund</h3>
+                <div className="space-y-2 text-blue-800 text-sm">
+                  <p>📧 <strong>Email:</strong> support@udin.in</p>
+                  <p>⏰ <strong>Time Limit:</strong> Within 7 days of payment</p>
+                  <p>💳 <strong>Processing Time:</strong> 7–10 business days to original payment method</p>
+                </div>
+              </div>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>All refund requests must include your transaction ID and reason for refund.</li>
+                <li>Refunds are processed to the original payment method used for the transaction.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Exceptions (Non-Refundable)</h2>
+              <div className="bg-gray-50 border border-gray-200 rounded-lg p-6">
+                <h3 className="font-semibold text-gray-900 mb-3">The following are not eligible for refunds:</h3>
+                <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                  <li>Customized/manual services once initiated.</li>
+                  <li>Cases of misuse, fraud, or breach of terms by the user.</li>
+                  <li>Services completed as per agreed specifications.</li>
+                </ul>
+              </div>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Dispute Resolution</h2>
+              <div className="space-y-4">
+                <div className="flex items-start space-x-4">
+                  <div className="w-8 h-8 bg-purple-500 rounded-full flex items-center justify-center text-white font-semibold text-sm">1</div>
+                  <div>
+                    <h3 className="font-semibold text-gray-900">Contact Customer Support</h3>
+                    <p className="text-gray-700 text-sm">
+                      Users should first approach our customer support team at support@udin.in for resolution.
+                    </p>
+                  </div>
+                </div>
+                
+                <div className="flex items-start space-x-4">
+                  <div className="w-8 h-8 bg-purple-500 rounded-full flex items-center justify-center text-white font-semibold text-sm">2</div>
+                  <div>
+                    <h3 className="font-semibold text-gray-900">Legal Resolution</h3>
+                    <p className="text-gray-700 text-sm">
+                      If unresolved, disputes shall be settled under Indian Arbitration Act, 1996.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <div className="bg-orange-50 border border-orange-200 rounded-lg p-6 mt-8">
+              <h3 className="text-lg font-semibold text-orange-900 mb-2">Need Help?</h3>
+              <p className="text-orange-800">
+                If you have questions about cancellations or refunds, our support team is here to help. 
+                Contact us at support@udin.in and we'll assist you with your request.
+              </p>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="mt-8 pt-8 border-t border-gray-200">
+            <div className="text-sm text-gray-600">
+              <p><strong>Website:</strong> www.udin.in</p>
+              <p><strong>Email:</strong> info@udin.in</p>
+              <p><strong>Contact:</strong> +91-9836777722</p>
+              <p className="mt-2"><strong>Prepared by:</strong> DialMyCA Private Limited</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CancellationRefundPolicy;

--- a/src/components/DeliveryPolicy.jsx
+++ b/src/components/DeliveryPolicy.jsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const DeliveryPolicy = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="bg-white rounded-lg shadow-sm p-8">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-8">
+            <h1 className="text-3xl font-bold text-gray-900">Delivery Policy</h1>
+            <button
+              onClick={() => navigate(-1)}
+              className="px-4 py-2 text-sm font-medium text-gray-600 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+            >
+              ← Back
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="prose prose-lg max-w-none">
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-8">
+              <div className="flex items-center mb-2">
+                <div className="w-8 h-8 bg-blue-500 rounded-full mr-3 flex items-center justify-center">
+                  <span className="text-white text-sm">📧</span>
+                </div>
+                <h3 className="font-semibold text-blue-900">Digital Delivery Platform</h3>
+              </div>
+              <p className="text-blue-800">
+                As udin.in is a digital platform, no physical delivery is involved. All services are delivered electronically.
+              </p>
+            </div>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Service Delivery</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Uploaded documents are verified and signed digitally.</li>
+                <li>Final signed documents are delivered in PDF format through the user dashboard.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Turnaround Time</h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="bg-green-50 border border-green-200 rounded-lg p-6">
+                  <div className="flex items-center mb-3">
+                    <div className="w-6 h-6 bg-green-500 rounded-full mr-2 flex items-center justify-center">
+                      <span className="text-white text-xs">⚡</span>
+                    </div>
+                    <h3 className="font-semibold text-green-900">Standard Documents</h3>
+                  </div>
+                  <p className="text-green-800 text-sm">24–72 hours</p>
+                  <p className="text-green-700 text-xs mt-2">Most common document types and standard processing</p>
+                </div>
+                
+                <div className="bg-orange-50 border border-orange-200 rounded-lg p-6">
+                  <div className="flex items-center mb-3">
+                    <div className="w-6 h-6 bg-orange-500 rounded-full mr-2 flex items-center justify-center">
+                      <span className="text-white text-xs">🔧</span>
+                    </div>
+                    <h3 className="font-semibold text-orange-900">Complex/Manual Jobs</h3>
+                  </div>
+                  <p className="text-orange-800 text-sm">Up to 7 business days</p>
+                  <p className="text-orange-700 text-xs mt-2">Specialized documents requiring manual review</p>
+                </div>
+              </div>
+              
+              <div className="mt-4 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+                <p className="text-yellow-800 text-sm">
+                  <strong>Note:</strong> Any delays beyond timelines will be notified to the user via email/SMS.
+                </p>
+              </div>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Tracking & Communication</h2>
+              
+              <div className="bg-gray-50 rounded-lg p-6 mb-6">
+                <h3 className="font-semibold text-gray-900 mb-4">Document Progress Tracking</h3>
+                <div className="flex items-center justify-between">
+                  <div className="flex flex-col items-center">
+                    <div className="w-10 h-10 bg-blue-500 rounded-full flex items-center justify-center text-white font-semibold">1</div>
+                    <span className="text-sm text-gray-600 mt-2 text-center">Uploaded</span>
+                  </div>
+                  <div className="flex-1 h-1 bg-blue-200 mx-2"></div>
+                  <div className="flex flex-col items-center">
+                    <div className="w-10 h-10 bg-blue-500 rounded-full flex items-center justify-center text-white font-semibold">2</div>
+                    <span className="text-sm text-gray-600 mt-2 text-center">Verified</span>
+                  </div>
+                  <div className="flex-1 h-1 bg-blue-200 mx-2"></div>
+                  <div className="flex flex-col items-center">
+                    <div className="w-10 h-10 bg-blue-500 rounded-full flex items-center justify-center text-white font-semibold">3</div>
+                    <span className="text-sm text-gray-600 mt-2 text-center">Signed</span>
+                  </div>
+                  <div className="flex-1 h-1 bg-blue-200 mx-2"></div>
+                  <div className="flex flex-col items-center">
+                    <div className="w-10 h-10 bg-green-500 rounded-full flex items-center justify-center text-white font-semibold">✓</div>
+                    <span className="text-sm text-gray-600 mt-2 text-center">Downloadable</span>
+                  </div>
+                </div>
+              </div>
+
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Each job gets a unique work ID for easy tracking.</li>
+                <li>Users can track real-time progress through their dashboard.</li>
+                <li>Status notifications are sent by SMS, email, and dashboard alerts.</li>
+              </ul>
+            </section>
+
+            <div className="bg-purple-50 border border-purple-200 rounded-lg p-6 mt-8">
+              <h3 className="text-lg font-semibold text-purple-900 mb-2">Stay Updated</h3>
+              <p className="text-purple-800">
+                We keep you informed at every step of the process. Track your document status in real-time and receive 
+                notifications when your documents are ready for download.
+              </p>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="mt-8 pt-8 border-t border-gray-200">
+            <div className="text-sm text-gray-600">
+              <p><strong>Website:</strong> www.udin.in</p>
+              <p><strong>Email:</strong> info@udin.in</p>
+              <p><strong>Contact:</strong> +91-9836777722</p>
+              <p className="mt-2"><strong>Prepared by:</strong> DialMyCA Private Limited</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeliveryPolicy;

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const Footer = () => {
   return (

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -44,10 +44,10 @@ const Footer = () => {
               QUICK LINKS
             </h3>
             <ul className="space-y-2">
-              <li><a href="#" className="text-sm text-gray-600 hover:text-gray-900">Login</a></li>
-              <li><a href="#" className="text-sm text-gray-600 hover:text-gray-900">Sign Up</a></li>
-              <li><a href="#" className="text-sm text-gray-600 hover:text-gray-900">Dashboard</a></li>
-              <li><a href="#" className="text-sm text-gray-600 hover:text-gray-900">Upload Documents</a></li>
+              <li><Link to="/login" className="text-sm text-gray-600 hover:text-gray-900">Login</Link></li>
+              <li><Link to="/register" className="text-sm text-gray-600 hover:text-gray-900">Sign Up</Link></li>
+              <li><Link to="/dashboard" className="text-sm text-gray-600 hover:text-gray-900">Dashboard</Link></li>
+              <li><Link to="/upload" className="text-sm text-gray-600 hover:text-gray-900">Upload Documents</Link></li>
             </ul>
           </div>
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -57,11 +57,11 @@ const Footer = () => {
               LEGAL
             </h3>
             <ul className="space-y-2">
-              <li><a href="#" className="text-sm text-gray-600 hover:text-gray-900">Terms & Conditions</a></li>
-              <li><a href="#" className="text-sm text-gray-600 hover:text-gray-900">Privacy Policy</a></li>
-              <li><a href="#" className="text-sm text-gray-600 hover:text-gray-900">Pricing Policy</a></li>
-              <li><a href="#" className="text-sm text-gray-600 hover:text-gray-900">Delivery Policy</a></li>
-              <li><a href="#" className="text-sm text-gray-600 hover:text-gray-900">Cancellation & Refund</a></li>
+              <li><Link to="/terms" className="text-sm text-gray-600 hover:text-gray-900">Terms & Conditions</Link></li>
+              <li><Link to="/privacy" className="text-sm text-gray-600 hover:text-gray-900">Privacy Policy</Link></li>
+              <li><Link to="/pricing-policy" className="text-sm text-gray-600 hover:text-gray-900">Pricing Policy</Link></li>
+              <li><Link to="/delivery-policy" className="text-sm text-gray-600 hover:text-gray-900">Delivery Policy</Link></li>
+              <li><Link to="/cancellation-refund" className="text-sm text-gray-600 hover:text-gray-900">Cancellation & Refund</Link></li>
             </ul>
           </div>
         </div>

--- a/src/components/PricingPolicy.jsx
+++ b/src/components/PricingPolicy.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const PricingPolicy = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="bg-white rounded-lg shadow-sm p-8">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-8">
+            <h1 className="text-3xl font-bold text-gray-900">Pricing Policy</h1>
+            <button
+              onClick={() => navigate(-1)}
+              className="px-4 py-2 text-sm font-medium text-gray-600 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+            >
+              ← Back
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="prose prose-lg max-w-none">
+            <div className="bg-purple-50 border border-purple-200 rounded-lg p-6 mb-8">
+              <p className="text-purple-800 font-medium">
+                At udin.in, we ensure complete transparency in pricing. Our pricing model is structured to suit
+                multiple document types and compliance requirements.
+              </p>
+            </div>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Scope</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Prices are quoted in Indian Rupees (INR).</li>
+                <li>Applicable GST will be added wherever required.</li>
+                <li>All service charges are listed clearly on the website.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Service Charges</h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="bg-gray-50 p-4 rounded-lg">
+                  <h3 className="font-semibold text-gray-900 mb-2">Audit Services</h3>
+                  <ul className="text-sm text-gray-700 space-y-1">
+                    <li>• Statutory Audit (turnover slabs)</li>
+                    <li>• Tax Audit</li>
+                  </ul>
+                </div>
+                <div className="bg-gray-50 p-4 rounded-lg">
+                  <h3 className="font-semibold text-gray-900 mb-2">Other Services</h3>
+                  <ul className="text-sm text-gray-700 space-y-1">
+                    <li>• Balance Sheet (final & provisional)</li>
+                    <li>• Auditor Appointment, ROC, Certificates</li>
+                  </ul>
+                </div>
+              </div>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Payment Terms</h2>
+              <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6 mb-4">
+                <div className="flex items-center mb-2">
+                  <div className="w-5 h-5 bg-yellow-400 rounded-full mr-2 flex items-center justify-center">
+                    <span className="text-yellow-800 text-xs font-bold">!</span>
+                  </div>
+                  <h3 className="font-semibold text-yellow-800">Important Payment Information</h3>
+                </div>
+                <p className="text-yellow-800 text-sm">
+                  100% advance payment is required for all services.
+                </p>
+              </div>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Payments are processed through Razorpay or other RBI-approved payment gateways.</li>
+                <li>No hidden charges—if any additional charges apply, they are disclosed before checkout.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Pricing Revision</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Prices may be revised from time to time without prior notice.</li>
+                <li>Revised pricing does not affect already-paid jobs.</li>
+              </ul>
+            </section>
+
+            <div className="bg-green-50 border border-green-200 rounded-lg p-6 mt-8">
+              <h3 className="text-lg font-semibold text-green-900 mb-2">Transparent Pricing Promise</h3>
+              <p className="text-green-800">
+                We believe in complete transparency. All charges are clearly displayed on our website before you proceed 
+                with your payment. No surprises, no hidden fees.
+              </p>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="mt-8 pt-8 border-t border-gray-200">
+            <div className="text-sm text-gray-600">
+              <p><strong>Website:</strong> www.udin.in</p>
+              <p><strong>Email:</strong> info@udin.in</p>
+              <p><strong>Contact:</strong> +91-9836777722</p>
+              <p className="mt-2"><strong>Prepared by:</strong> DialMyCA Private Limited</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PricingPolicy;

--- a/src/components/PrivacyPolicy.jsx
+++ b/src/components/PrivacyPolicy.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const PrivacyPolicy = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="bg-white rounded-lg shadow-sm p-8">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-8">
+            <h1 className="text-3xl font-bold text-gray-900">Privacy Policy</h1>
+            <button
+              onClick={() => navigate(-1)}
+              className="px-4 py-2 text-sm font-medium text-gray-600 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+            >
+              ← Back
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="prose prose-lg max-w-none">
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Information We Collect</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Personal details: Name, contact number, email, address.</li>
+                <li>Uploaded documents for signing.</li>
+                <li>Payment details (handled by third-party gateway, not stored by us).</li>
+                <li>Technical data (IP address, browser, device info).</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">How We Use Data</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Verify and authenticate documents.</li>
+                <li>Deliver services and provide updates.</li>
+                <li>Process payments securely.</li>
+                <li>Internal research, audits, and compliance.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Data Protection Measures</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Encrypted data storage and transfer.</li>
+                <li>Access to data restricted to authorized staff only.</li>
+                <li>Multi-level authentication for document vault access.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">User Rights</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Right to access and download stored documents.</li>
+                <li>Right to request deletion of personal data (except regulatory records).</li>
+                <li>Right to withdraw consent at any time (services will stop accordingly).</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Third-party Sharing</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>We do not sell user data.</li>
+                <li>Data may be shared with regulators, government bodies, or courts if required by law.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Cookies Policy</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>We use cookies for analytics, session management, and better UX.</li>
+                <li>Users can disable cookies via browser settings.</li>
+              </ul>
+            </section>
+
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 mt-8">
+              <h3 className="text-lg font-semibold text-blue-900 mb-2">Your Privacy Matters</h3>
+              <p className="text-blue-800">
+                At UDIN.in, we are committed to protecting your privacy and ensuring the security of your personal information. 
+                If you have any questions about this privacy policy or how we handle your data, please contact us at info@udin.in.
+              </p>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="mt-8 pt-8 border-t border-gray-200">
+            <div className="text-sm text-gray-600">
+              <p><strong>Website:</strong> www.udin.in</p>
+              <p><strong>Email:</strong> info@udin.in</p>
+              <p><strong>Contact:</strong> +91-9836777722</p>
+              <p className="mt-2"><strong>Prepared by:</strong> DialMyCA Private Limited</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PrivacyPolicy;

--- a/src/components/TermsConditions.jsx
+++ b/src/components/TermsConditions.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const TermsConditions = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="bg-white rounded-lg shadow-sm p-8">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-8">
+            <h1 className="text-3xl font-bold text-gray-900">Terms & Conditions</h1>
+            <button
+              onClick={() => navigate(-1)}
+              className="px-4 py-2 text-sm font-medium text-gray-600 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+            >
+              ← Back
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="prose prose-lg max-w-none">
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Acceptance</h2>
+              <p className="text-gray-700 leading-relaxed">
+                By using udin.in, you agree to abide by these terms. If you do not agree, please discontinue use.
+              </p>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">User Obligations</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Provide genuine documents. Fake or fraudulent submissions will lead to termination and legal action.</li>
+                <li>Maintain confidentiality of your login credentials.</li>
+                <li>Ensure timely payment to avoid delays in services.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Scope of Services</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>UDIN.in acts as a facilitator of document verification and signing.</li>
+                <li>Responsibility is limited to delivering verified and digitally signed files.</li>
+                <li>We do not represent or guarantee acceptance of documents by external authorities/regulators.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Payment Terms</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Payments are non-transferable.</li>
+                <li>Refunds, if applicable, are subject to the Refund Policy.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Limitation of Liability</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>UDIN.in shall not be liable for indirect, incidental, or consequential damages.</li>
+                <li>Our maximum liability is limited to the amount paid for the disputed service.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Prohibited Activities</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Uploading malicious, offensive, or fraudulent content.</li>
+                <li>Attempting to hack, reverse-engineer, or misuse the platform.</li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Governing Law & Jurisdiction</h2>
+              <ul className="list-disc pl-6 space-y-2 text-gray-700">
+                <li>Governed by the laws of India.</li>
+                <li>Jurisdiction lies with courts in Kolkata, West Bengal.</li>
+              </ul>
+            </section>
+          </div>
+
+          {/* Footer */}
+          <div className="mt-8 pt-8 border-t border-gray-200">
+            <div className="text-sm text-gray-600">
+              <p><strong>Website:</strong> www.udin.in</p>
+              <p><strong>Email:</strong> info@udin.in</p>
+              <p><strong>Contact:</strong> +91-9836777722</p>
+              <p className="mt-2"><strong>Prepared by:</strong> DialMyCA Private Limited</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TermsConditions;


### PR DESCRIPTION
## Purpose
The user requested the creation of terms, privacy policy, and other legal pages that can be linked from the footer, following documentation requirements for the website.

## Code changes
- **New policy components**: Created 5 new policy page components (TermsConditions, PrivacyPolicy, PricingPolicy, DeliveryPolicy, CancellationRefundPolicy)
- **Routing setup**: Added routes for all policy pages (/terms, /privacy, /pricing-policy, /delivery-policy, /cancellation-refund)
- **Component structure**: Each policy page includes:
  - Responsive layout with consistent styling
  - Back navigation button
  - Structured content sections with proper typography
  - Company contact information in footer
  - Visual elements like colored cards and icons for better readability

The policy pages cover essential legal aspects including user obligations, data protection, refund conditions, and dispute resolution procedures.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/41af6d5d871b4368b27869540e4674f1/pixel-forge)

👀 [Preview Link](https://41af6d5d871b4368b27869540e4674f1-pixel-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>41af6d5d871b4368b27869540e4674f1</projectId>-->
<!--<branchName>pixel-forge</branchName>-->